### PR TITLE
Requests was going zoom and I said bad and bonked it

### DIFF
--- a/src/components/staff/stats/stats.tsx
+++ b/src/components/staff/stats/stats.tsx
@@ -20,7 +20,7 @@ export default function Stats() {
         fetchStats()
         const timeout = setTimeout(()=>{
             fetchStats()
-        }, 1000)
+        }, 2500)
 
         return () => {
             clearTimeout(timeout)


### PR DESCRIPTION
I was sending requests to /api/stats every second, thankfully I have caching otherwise my Spotify api details would have been rate limited by now