### PR TITLE
Update policy edit button style: change button color to primary for better visability. IDFK, AI just blabbered 'cuz I didn't like how both edit and delete was the same on the policy edit page

### DIFF
--- a/src/components/staff/directors/policies/viewPolicies.tsx
+++ b/src/components/staff/directors/policies/viewPolicies.tsx
@@ -12,7 +12,7 @@ export default async function ViewPolicies({res} : {res: Response}) {
                         <div className="px-4 py-2 rounded-xl bg-base-300 border border-solid border-base-300 justify-start w-full font-semibold text-xl flex flex-row">
                             {policy.name}
                             <div className="ml-auto flex flex-row gap-4">
-                                <Link className="btn btn-error btn-sm" href={`/staff/director/policies/${policy.id}`}>Edit</Link>
+                                <Link className="btn btn-primary btn-sm" href={`/staff/director/policies/${policy.id}`}>Edit</Link>
                                 <DeleteButton id={policy.id} />
                             </div>
                         </div>


### PR DESCRIPTION
This pull request includes a change to the `ViewPolicies` component to update the styling of the "Edit" button.

Styling update:

* [`src/components/staff/directors/policies/viewPolicies.tsx`](diffhunk://#diff-5d8429717d943d446f4d74dfadab3d7f2a1c8a32ea872799578e8c8680b404d1L15-R15): Changed the "Edit" button's class from `btn-error` to `btn-primary` to update its appearance.