### PR TITLE
Fixed permissions perm check

### DIFF
--- a/src/app/staff/director/permissions/[id]/page.tsx
+++ b/src/app/staff/director/permissions/[id]/page.tsx
@@ -12,7 +12,7 @@ export default async function Page(context: {params: Promise<{id: string}>}) {
     const session = await auth()
 
     if (!session || !session.user || !session.user.providerId) redirect('/auth')
-    if (!await hasPermission(session.user.providerId, Permissions.VIEW_PERMISSIONS)) return <div>Unauthorized</div>
+    if (!await hasPermission(session.user.providerId, Permissions.EDIT_PERMISSIONS)) return <div>Unauthorized</div>
 
     const params = await context.params
     if (!params.id) {

--- a/src/app/staff/director/permissions/create/page.tsx
+++ b/src/app/staff/director/permissions/create/page.tsx
@@ -11,7 +11,7 @@ export default async function Page() {
     const session = await auth()
 
     if (!session || !session.user || !session.user.providerId) redirect('/auth')
-    if (!await hasPermission(session.user.providerId, Permissions.VIEW_PERMISSIONS)) return <div>Unauthorized</div>
+    if (!await hasPermission(session.user.providerId, Permissions.CREATE_PERMISSIONS)) return <div>Unauthorized</div>
 
     return (
         <div className="mx-auto mt-4 overflow-auto container">


### PR DESCRIPTION
This pull request includes changes to the permissions checks in the `Page` components for the staff director permissions pages. The updates ensure that the correct permissions are verified before allowing access to the respective pages.

Changes to permissions checks:

* `src/app/staff/director/permissions/[id]/page.tsx`: Updated the permission check from `Permissions.VIEW_PERMISSIONS` to `Permissions.EDIT_PERMISSIONS` to ensure users have the correct edit permissions. ([src/app/staff/director/permissions/[id]/page.tsxL15-R15](diffhunk://#diff-b09a42920c8249277c8ec8d96f140e25062d52223eec6b86fdedae87ef3fd93bL15-R15))
* [`src/app/staff/director/permissions/create/page.tsx`](diffhunk://#diff-70c9149d6f6da62ab8495d3d6e356bc69f5af8d754b7529e84219a08b373e91aL14-R14): Updated the permission check from `Permissions.VIEW_PERMISSIONS` to `Permissions.CREATE_PERMISSIONS` to ensure users have the correct create permissions.