### PR TITLE
Fix routing path for policy redirection in editPolicy component

### DIFF
--- a/src/components/staff/directors/policies/editPolicy.tsx
+++ b/src/components/staff/directors/policies/editPolicy.tsx
@@ -17,7 +17,7 @@ export default function ViewPolicy({policy}: {policy: {id: number, name: string,
             body: JSON.stringify({name: title, text})
         })
 
-        router.push('/staff/directors/policies')
+        router.push('/staff/director/policies')
     }
 
     return (


### PR DESCRIPTION
This pull request includes a small but important change to the `editPolicy.tsx` file. The change corrects a routing path to ensure the application navigates to the correct URL after a policy update.

* [`src/components/staff/directors/policies/editPolicy.tsx`](diffhunk://#diff-2fffec8b05221861cd2e209297fa572cd108981c964a7cabebd7b908df41dfd3L20-R20): Corrected the routing path from `/staff/directors/policies` to `/staff/director/policies`.